### PR TITLE
DEV-3878: Fix buildpack incorrectly nested style tag

### DIFF
--- a/bin/steps/poetry
+++ b/bin/steps/poetry
@@ -35,6 +35,10 @@ if [ ! "$SKIP_POETRY_INSTALL" ]; then
         # Configure Poetry to install dependencies in the existing virtual environment
         /app/.heroku/python/bin/poetry config virtualenvs.create false &> /dev/null
 
+        # Disable experimental installer to prevent incorrectly nested style tag errors
+        # https://github.com/python-poetry/poetry/issues/3010
+        /app/.heroku/python/bin/poetry config experimental.new-installer false &> /dev/null
+
         # Install the test dependencies, for CI.
         if [ "$INSTALL_TEST" ]; then
             puts-step "Installing dependencies (including test dependencies) with Poetry $POETRY_VERSION"


### PR DESCRIPTION
[Jira card](https://skilljar.atlassian.net/browse/DEV-3878)

- We observed `Incorrectly nested style tag found` errors that caused a review app build to fail (see [Slack discussion](https://skilljar.slack.com/archives/CAMAHFNHF/p1610664918014200)):

```
         • Updating futures (3.3.0 -> 3.2.0)
         • Installing django (1.11.29)
         • Installing google-auth (1.24.0)
       ValueError
       Incorrectly nested style tag found.
         • Installing jinja2 (2.11.2)
         • Installing lxml (4.6.2)
         • Installing oauthlib (0.6.1)
         • Installing pyopenssl (18.0.0)
         • Installing sqlparse (0.2.3)
         • Installing text-unidecode (1.3)
 !     Push rejected, failed to compile Python app.
 !     Push failed
```

- From https://github.com/python-poetry/poetry/issues/3010:
>The workaround is to disable the new installer: poetry config experimental.new-installer false

- This doesn't happen for _every_ Jenkins deployment, and we haven't observed this on a Drone deployment

#### Testing

1. On a review app, change the `https://github.com/skilljar/heroku-buildpack-python.git` buildpack to `https://github.com/skilljar/heroku-buildpack-python.git#DEV-3878-fix-buildpack-incorrectly-nested-style-tag`.
2. Push an empty commit to trigger a new review app build (`git commit --allow-empty -m 'Trigger build'`)